### PR TITLE
Fix operator roles

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,8 +2,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: manager-role
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -26,6 +35,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - patch
 - apiGroups:
   - operator.kyma-project.io
   resources:

--- a/controllers/sample_controller_rendered_resources.go
+++ b/controllers/sample_controller_rendered_resources.go
@@ -61,6 +61,8 @@ type ManifestResources struct {
 //+kubebuilder:rbac:groups=operator.kyma-project.io,resources=samples/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;get;list;watch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;patch;delete
+//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=create;patch;delete
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SampleReconciler) SetupWithManager(mgr ctrl.Manager, rateLimiter RateLimiter) error {


### PR DESCRIPTION
**Description**
This PR fixes permissions problem for the template-operator: when run with RBAC in dual-cluster setup, it lacks permissions to create/delete `configmaps` and `deployments`

Edit:
the controller requires this because it creates a `redis` deployment and a `sample-redis-config` configmaps in a configured namespace.

Changes proposed in this pull request:

- Extends the clusterrole with RBAC giving full permissions for `configmaps` and `deployments`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
