### PR TITLE
chore(infra): Adjust GitHub Action linters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "gomod"
-      include: "scope"
+      prefix: "chore(dependabot)"
   - package-ecosystem: "docker"
     directory: "/"
     labels:
@@ -20,5 +19,4 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "docker"
-      include: "scope"
+      prefix: "chore(dependabot)"

--- a/.github/workflows/lint-conventional-prs.yml
+++ b/.github/workflows/lint-conventional-prs.yml
@@ -1,0 +1,30 @@
+name: Lint PR Title
+run-name: ${{github.event.pull_request.title}}
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  check:
+    name: Check Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            deps
+            chore
+            docs
+            feat
+            fix
+            test
+          requireScope: false
+          # https://regex101.com/r/YybDgS/1
+          subjectPattern: ^([A-Z].*[^.]|bump .*)$

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -1,0 +1,23 @@
+name: Lint Markdown Links
+run-name: ${{github.event.pull_request.title}}
+
+on:
+  pull_request:
+  schedule:
+    # Run every day at 5:00 AM
+    - cron: "0 5 * * *"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'no'
+          config-file: '.mlc.config.json'
+          folder-path: '.'
+          max-depth: -1
+          check-modified-files-only: 'yes'
+          base-branch: 'main'

--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -1,0 +1,9 @@
+{
+  "replacementPatterns": [
+    {
+      "_comment": "a replacement rule for all the in-repository references",
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/"
+    }
+  ]
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of conduct
 
-Each contributor and maintainer of this project agrees to follow the [community Code of Conduct](https://github.com/kyma-project/community/blob/main/contributing/01-code-of-conduct.md) that relies on the CNCF Code of Conduct. Read it to learn about the agreed standards of behavior, shared values that govern our community, and details on how to report any suspected Code of Conduct violations.
+Each contributor and maintainer of this project agrees to follow the [community Code of Conduct](https://github.com/kyma-project/community/blob/main/docs/contributing/01-code-of-conduct.md) that relies on the CNCF Code of Conduct. Read it to learn about the agreed standards of behavior, shared values that govern our community, and details on how to report any suspected Code of Conduct violations.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ However, in Kyma we opinionated here, since managed use-cases usually require un
     ```
 * [kyma CLI](https://storage.googleapis.com/kyma-cli-stable/kyma-darwin)
 * An OCI Registry to host OCI Image
-  * Follow our [Provision cluster and OCI registry](https://github.com/kyma-project/lifecycle-manager/blob/main/docs/developer/provision-cluster-and-registry.md) guide to create a local registry provided by k3d
-  * Or using [Google Container Registry (GCR)](https://github.com/kyma-project/lifecycle-manager/blob/main/docs/developer/prepare-gcr-registry.md) guide for a remote registry.
+  * Follow our [Provision cluster and OCI registry](https://github.com/kyma-project/lifecycle-manager/blob/main/docs/developer-tutorials/provision-cluster-and-registry.md) guide to create a local registry provided by k3d
+  * Or using [Google Container Registry (GCR)](https://github.com/kyma-project/lifecycle-manager/blob/main/docs/developer-tutorials/prepare-gcr-registry.md) guide for a remote registry.
 ### Generate kubebuilder operator
 
 1. Initialize `kubebuilder` project. Please make sure domain is set to `kyma-project.io`, the following command should execute in `test-operator` folder.
@@ -147,7 +147,7 @@ If the module operator will be deployed under same namespace with other operator
 
 2. Include all resources (e.g: [manager.yaml](config/manager/manager.yaml)) which contain label selectors by using `commonLabels`.
 
-Further reading: [Kustomize built-in commonLabels](https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/commonlabels.go)
+Further reading: [Kustomize built-in commonLabels](https://github.com/kubernetes-sigs/kustomize/blob/master/api/internal/konfig/builtinpluginconsts/commonlabels.go)
 
 #### Steps API definition
 
@@ -245,7 +245,7 @@ This feature is supported by [kubebuilder grafana plugin](https://book.kubebuild
 
 ### RBAC
 Make sure you have appropriate authorizations assigned to you controller binary, before you run it inside a cluster (not locally with `make run`).
-The Sample CR [controller implementation](controllers/sample_controller.go) includes rbac generation (via kubebuilder) for all resources across all API groups.
+The Sample CR [controller implementation](controllers/sample_controller_rendered_resources.go) includes rbac generation (via kubebuilder) for all resources across all API groups.
 This should be adjusted according to the chart manifest resources and reconciliation types.
 
 Towards the earlier stages of your operator development RBACs could simply accommodate all resource types and adjusted later, as per your requirements.


### PR DESCRIPTION
Changes proposed in this pull request:

- Configure the Conventional Commits linter to a PR title
- Configure Dependabot's dependency bumps to adhere to the Conventional Commits spec
- Configure markdown files links checker
- Fix broken links in documentation
