### PR TITLE
chore: Update channel to regular

### DIFF
--- a/module-config.yaml
+++ b/module-config.yaml
@@ -1,5 +1,5 @@
 name: kyma-project.io/module/template-operator
-channel: fast
+channel: regular
 version: v1.0.0
 manifest: template-operator.yaml
 security: sec-scanners-config.yaml


### PR DESCRIPTION
The regular channel is the default channel, aligned with it to avoid additional configuration when enable module