### PR TITLE
feat: Add final-deletion-state Flag to Set Custom State When DeletionTimestamp is Set

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -27,6 +27,12 @@ patches:
         value: --final-state=Ready
     target:
       kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --final-deletion-state=Deleting
+    target:
+      kind: Deployment
 
 components:
 - ../crd

--- a/controllers/sample_controller_rendered_resources_test.go
+++ b/controllers/sample_controller_rendered_resources_test.go
@@ -48,6 +48,11 @@ var _ = Describe("Sample CR is created with the correct resource path", Ordered,
 			WithPolling(500 * time.Millisecond).
 			Should(Equal(CRStatus{State: v1alpha1.StateWarning,
 				InstallConditionStatus: metav1.ConditionTrue, Err: nil}))
+		Consistently(getCRStatus(sampleCRKey)).
+			WithTimeout(5 * time.Second).
+			WithPolling(100 * time.Millisecond).
+			Should(Equal(CRStatus{State: v1alpha1.StateWarning,
+				InstallConditionStatus: metav1.ConditionTrue, Err: nil}))
 	})
 
 	It("should delete when FinalDeletionState set to Deleting", func() {

--- a/controllers/sample_controller_rendered_resources_test.go
+++ b/controllers/sample_controller_rendered_resources_test.go
@@ -1,12 +1,11 @@
 package controllers_test
 
 import (
-	"time"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes"
+	"time"
 
 	"github.com/kyma-project/template-operator/api/v1alpha1"
 
@@ -22,36 +21,60 @@ var (
 	podName    = "busybox-pod"
 )
 
-func testFn(sampleCR *v1alpha1.Sample, desiredState v1alpha1.State, desiredConditionStatus metav1.ConditionStatus,
-	resourceCheck func(g Gomega) bool,
-) {
-	// create SampleCR
-	Expect(k8sClient.Create(ctx, sampleCR)).To(Succeed())
-
-	// check if SampleCR is in the desired State
+var _ = Describe("Sample CR is created with the correct resource path", Ordered, func() {
+	sampleCR := createSampleCR(sampleName, "./test/busybox/manifest")
 	sampleCRKey := client.ObjectKeyFromObject(sampleCR)
-	Eventually(getCRStatus(sampleCRKey)).
-		WithTimeout(30 * time.Second).
-		WithPolling(500 * time.Millisecond).
-		Should(Equal(CRStatus{State: desiredState, InstallConditionStatus: desiredConditionStatus, Err: nil}))
 
-	// check if deployed resources are up and running
-	Eventually(resourceCheck).
-		WithTimeout(30 * time.Second).
-		WithPolling(500 * time.Millisecond).
-		Should(BeTrue())
+	It("should create SampleCR and resources", func() {
+		Expect(k8sClient.Create(ctx, sampleCR)).To(Succeed())
 
-	// clean up SampleCR
-	Expect(k8sClient.Delete(ctx, sampleCR)).To(Succeed())
+		Eventually(getCRStatus(sampleCRKey)).
+			WithTimeout(30 * time.Second).
+			WithPolling(500 * time.Millisecond).
+			Should(Equal(CRStatus{State: v1alpha1.StateReady, InstallConditionStatus: metav1.ConditionTrue, Err: nil}))
 
-	// check installed resources are deleted
-	Eventually(checkDeleted(sampleCRKey)).
-		WithTimeout(30 * time.Second).
-		WithPolling(500 * time.Millisecond).
-		Should(BeTrue())
-}
+		Eventually(getPod(podNs, podName)).
+			WithTimeout(30 * time.Second).
+			WithPolling(500 * time.Millisecond).
+			Should(BeTrue())
+	})
 
-func createSampleCR(sampleName string, path string) *v1alpha1.Sample {
+	It("should set state to Warning when deleted after setting FinalDeletionState", func() {
+		reconciler.FinalDeletionState = v1alpha1.StateWarning
+		Expect(k8sClient.Delete(ctx, sampleCR)).To(Succeed())
+
+		Eventually(getCRStatus(sampleCRKey)).
+			WithTimeout(30 * time.Second).
+			WithPolling(500 * time.Millisecond).
+			Should(Equal(CRStatus{State: v1alpha1.StateWarning,
+				InstallConditionStatus: metav1.ConditionTrue, Err: nil}))
+	})
+
+	It("should delete when FinalDeletionState set to Deleting", func() {
+		reconciler.FinalDeletionState = v1alpha1.StateDeleting
+		Eventually(checkDeleted(sampleCRKey)).
+			WithTimeout(30 * time.Second).
+			WithPolling(500 * time.Millisecond).
+			Should(BeTrue())
+	})
+})
+
+var _ = Describe("Sample CR is created with an incorrect resource path", Ordered, func() {
+	sampleCR := createSampleCR(sampleName, "./invalid/path")
+	sampleCRKey := client.ObjectKeyFromObject(sampleCR)
+
+	It("should create SampleCR in Error state", func() {
+		Expect(k8sClient.Create(ctx, sampleCR)).To(Succeed())
+		Eventually(getCRStatus(sampleCRKey)).
+			WithTimeout(30 * time.Second).
+			WithPolling(500 * time.Millisecond).
+			Should(Equal(CRStatus{State: v1alpha1.StateError, InstallConditionStatus: metav1.ConditionFalse, Err: nil}))
+
+		Expect(k8sClient.Delete(ctx, sampleCR)).To(Succeed())
+	})
+})
+
+func createSampleCR(sampleName, path string) *v1alpha1.Sample {
 	return &v1alpha1.Sample{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       string(v1alpha1.SampleKind),
@@ -128,21 +151,3 @@ func checkDeleted(sampleObjKey client.ObjectKey) func(g Gomega) bool {
 		return false
 	}
 }
-
-var _ = Describe("Sample CR scenarios", Ordered, func() {
-	DescribeTable("should set SampleCR to appropriate states",
-		testFn,
-		Entry("when Sample CR is created with the correct resource path",
-			createSampleCR(sampleName, "./test/busybox/manifest"),
-			v1alpha1.StateReady,
-			metav1.ConditionTrue,
-			getPod(podNs, podName),
-		),
-		Entry("when Sample CR is created with an incorrect resource path",
-			createSampleCR(sampleName, "invalid/path"),
-			v1alpha1.StateError,
-			metav1.ConditionFalse,
-			func(g Gomega) bool { return true },
-		),
-	)
-})

--- a/controllers/sample_controller_rendered_resources_test.go
+++ b/controllers/sample_controller_rendered_resources_test.go
@@ -16,13 +16,12 @@ import (
 )
 
 var (
-	sampleName = "kyma-sample"
-	podNs      = "redis"
-	podName    = "busybox-pod"
+	podNs   = "redis"
+	podName = "busybox-pod"
 )
 
 var _ = Describe("Sample CR is created with the correct resource path", Ordered, func() {
-	sampleCR := createSampleCR(sampleName, "./test/busybox/manifest")
+	sampleCR := createSampleCR("valid-sample", "./test/busybox/manifest")
 	sampleCRKey := client.ObjectKeyFromObject(sampleCR)
 
 	It("should create SampleCR and resources", func() {
@@ -65,7 +64,7 @@ var _ = Describe("Sample CR is created with the correct resource path", Ordered,
 })
 
 var _ = Describe("Sample CR is created with an incorrect resource path", Ordered, func() {
-	sampleCR := createSampleCR(sampleName, "./invalid/path")
+	sampleCR := createSampleCR("invalid-sample", "./invalid/path")
 	sampleCRKey := client.ObjectKeyFromObject(sampleCR)
 
 	It("should create SampleCR in Error state", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -105,10 +105,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	reconciler = &controllers.SampleReconciler{
-		Client:        k8sManager.GetClient(),
-		Scheme:        scheme.Scheme,
-		EventRecorder: k8sManager.GetEventRecorderFor("tests"),
-		FinalState:    operatorkymaprojectiov1alpha1.StateReady,
+		Client:             k8sManager.GetClient(),
+		Scheme:             scheme.Scheme,
+		EventRecorder:      k8sManager.GetEventRecorderFor("tests"),
+		FinalState:         operatorkymaprojectiov1alpha1.StateReady,
+		FinalDeletionState: operatorkymaprojectiov1alpha1.StateDeleting,
 	}
 
 	err = reconciler.SetupWithManager(k8sManager, rateLimiter)

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ type FlagVar struct {
 	rateLimiterFrequency int
 	rateLimiterBurst     int
 	finalState           string
+	finalDeletionState   string
 	printVersion         bool
 }
 
@@ -116,10 +117,11 @@ func main() {
 	}
 
 	if err = (&controllers.SampleReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		EventRecorder: mgr.GetEventRecorderFor(operatorName),
-		FinalState:    v1alpha1.State(flagVar.finalState),
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		EventRecorder:      mgr.GetEventRecorderFor(operatorName),
+		FinalState:         v1alpha1.State(flagVar.finalState),
+		FinalDeletionState: v1alpha1.State(flagVar.finalDeletionState),
 	}).SetupWithManager(mgr, rateLimiter); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sample")
 		os.Exit(1)
@@ -159,6 +161,8 @@ func defineFlagVar() *FlagVar {
 		"Indicates the failure max delay in seconds")
 	flag.StringVar(&flagVar.finalState, "final-state", string(v1alpha1.StateReady),
 		"Customize final state, to mimic state behaviour like Ready, Warning")
+	flag.StringVar(&flagVar.finalDeletionState, "final-deletion-state", string(v1alpha1.StateDeleting),
+		"Customize final state when module marked for deletion, to mimic state behaviour like Ready, Warning")
 	flag.BoolVar(&flagVar.printVersion, "version", false, "Prints the operator version and exits")
 	return flagVar
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Added new flag `final-deletion-state` to Template-Operator Manager - can be used to set a custom state when deletion timestamp is set (default Deleting)
- Added default state as a patch in kustomization.yaml

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #147 