### PR TITLE
chore: Bump docker builder base image to `golang:1.22-alpine`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.22-alpine as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Bump docker builder base image to `golang:1.22-alpine`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.com/kyma-project/runtime-watcher/pull/203
- https://github.com/kyma-project/runtime-watcher/pull/202

**Performed Local Tests**

- `make docker-build` ✅ 
- `make kustomize` ✅ 
- `make build-manifests` ✅ 
- `kyma alpha create module -p ./ --version 1.2.3 --registry k3d-registry.localhost:5111 --insecure --module-config-file ./module-config.yaml --module-archive-version-overwrite` ✅ 
- with template-operator applied to kcp:
  - enabled template-operator module in SKR; kyma transitioning to ready state ✅ 
  - disabled template-operator module in SKR; kyma transitioning to ready state ✅ 