### PR TITLE
chore: Bump golang from `1.22.1` to `1.22.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.1-alpine as builder
+FROM golang:1.22.2-alpine as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/template-operator/api
 
-go 1.22.1
+go 1.22.2
 
 require k8s.io/apimachinery v0.28.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/template-operator
 
-go 1.22.1
+go 1.22.2
 
 replace github.com/kyma-project/template-operator/api => ./api
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- replacement for https://github.com/kyma-project/template-operator/pull/173 that bumps the version in both, dockerfile and go.mod file

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
