### PR TITLE
feat: Add GitHub Action for template-operator Image Build

### DIFF
--- a/.github/workflows/pull-build-template-operator.yml
+++ b/.github/workflows/pull-build-template-operator.yml
@@ -1,0 +1,35 @@
+name: pull-build-template-operator
+
+on:
+  push:
+    branches:
+      - main  # This will get tagged with `latest` and `v{{DATE}}-{{COMMIT_HASH_SHORT}}`
+  pull_request_target:
+    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
+jobs:
+  compute-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get_tag.outputs.TAG }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get the latest tag
+        id: get_tag
+        if: github.event_name == 'push'
+        run: echo "tag=latest" >> $GITHUB_OUTPUT
+      - name: Echo the tag
+        run: echo ${{ steps.get_tag.outputs.TAG }}
+  build-image:
+    needs: compute-tag
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: template-operator
+      dockerfile: Dockerfile
+      context: .
+      tags: ${{ needs.compute-tag.outputs.tag }}

--- a/.github/workflows/pull-build-template-operator.yml
+++ b/.github/workflows/pull-build-template-operator.yml
@@ -27,7 +27,7 @@ jobs:
         run: echo ${{ steps.get_tag.outputs.TAG }}
   build-image:
     needs: compute-tag
-    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: template-operator
       dockerfile: Dockerfile


### PR DESCRIPTION
**Description**
This PR aims to make this `template-operator` repository use GitHub Actions for building images, drop dependency on Prow Jobs for image builds.

**Related Issues**
- Resolves a part of [this issue](https://github.com/kyma-project/lifecycle-manager/issues/1811)
- Implementation in support of [this issue](https://github.com/kyma-project/lifecycle-manager/issues/1811)