### PR TITLE
chore: Rename pull-build-template-operator to build-template-operator

### DIFF
--- a/.github/workflows/build-template-operator.yml
+++ b/.github/workflows/build-template-operator.yml
@@ -1,4 +1,4 @@
-name: pull-build-template-operator
+name: build-template-operator
 
 on:
   push:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Renaming `pull-build-template-operator` to `build-template-operator`

**Related Issues**
In cooperation with https://github.com/kyma-project/lifecycle-manager/issues/1811