### PR TITLE
fix: Use workflow call to trigger image build during release

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main  # This will get tagged with `latest` and `v{{DATE}}-{{COMMIT_HASH_SHORT}}`
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Additional tag for built images'
+        required: false
+        type: string
+        default: ""
   pull_request_target:
     types: [ opened, edited, synchronize, reopened, ready_for_review ]
 
@@ -25,8 +29,8 @@ jobs:
       - name: Get the latest tag
         id: get_tag
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
-            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          if [[ "${{ inputs.tag }}" != "" ]]; then
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -50,16 +50,10 @@ jobs:
         run: |
           RELEASE_ID=$(./scripts/release/draft_release.sh ${{ github.event.inputs.name }})
           echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
-      - name: Create lightweight tag
+      - name: Create tag
         run: |
           git tag ${{ github.event.inputs.name }}
           git push origin ${{ github.event.inputs.name }} --tags
-      - name: Wait for the Docker image
-        timeout-minutes: 20
-        env:
-          ITERATIONS: 40
-          SLEEP_SECONDS: 30
-        run: ./scripts/release/wait_for_image.sh ${{ env.IMAGE_REPO }}:${{ github.event.inputs.name }} $ITERATIONS $SLEEP_SECONDS
       - name: Create release assets
         id: create-assets
         env:
@@ -68,7 +62,11 @@ jobs:
         run: ./scripts/release/upload_assets.sh
     outputs:
       release_id: ${{ steps.draft-release.outputs.release_id }}
-
+  builds:
+    needs: draft-release
+    uses: ./.github/workflows/build-image.yml
+    with:
+      tag: "${{ github.event.inputs.name }}"
   publish-release:
     name: Publish release
     needs: [validate-head-status, draft-release]
@@ -78,6 +76,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Wait for the Docker image
+        timeout-minutes: 20
+        env:
+          ITERATIONS: 40
+          SLEEP_SECONDS: 30
+        run: ./scripts/release/wait_for_image.sh ${{ env.IMAGE_REPO }}:${{ github.event.inputs.name }} $ITERATIONS $SLEEP_SECONDS
       - name: Publish release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Due to the [restriction](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow) that use default `GITHUB_TOKEN` to push tags will not trigger related workflow (`build-image.yml`), this PR refactored the create-release workflow to use build-image specifically. 

Tested in my fork: https://github.com/ruanxin/template-operator/actions/runs/10705244987

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
