### PR TITLE
chore: Revert "Re-Add 'latest' tag to sec-scanners-config (#312)"

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -6,7 +6,6 @@ checkmarxOne:
   checkmarx_preset: golang
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/template-operator:1.0.1
-  - europe-docker.pkg.dev/kyma-project/prod/template-operator:latest
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
This reverts commit d051f5a4f6124220653b75dde43c3cd9ea78f9f4.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Needs to be reverted as of https://github.com/kyma-project/modulectl/issues/139
  - this fails the lifecycle-manager pipeline as we can't build the template-operator anymore in the e2e tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
