### PR TITLE
chore: Limit GH workflow permissions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,5 +1,9 @@
 name: Build Image
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 on:
   push:
     branches:
@@ -13,9 +17,6 @@ on:
         default: ""
   pull_request_target:
     types: [ opened, edited, synchronize, reopened, ready_for_review ]
-permissions:
-  id-token: write # This is required for requesting the JWT token
-  contents: read # This is required for actions/checkout
 
 jobs:
   get-custom-tags:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,8 +1,7 @@
 name: "Create release"
 
-env:
-  IMAGE_REPO: europe-docker.pkg.dev/kyma-project/prod/template-operator
-  CODE_REPOSITORY: kyma-project/template-operator
+permissions: { }
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +13,10 @@ on:
         description: "Changelog since"
         default: ""
         required: false
+
+env:
+  IMAGE_REPO: europe-docker.pkg.dev/kyma-project/prod/template-operator
+  CODE_REPOSITORY: kyma-project/template-operator
 
 jobs:
   validate-release:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,5 +1,7 @@
 name: Integration Tests
 
+permissions: { }
+
 on:
   pull_request:
     branches: ["main"]

--- a/.github/workflows/lint-conventional-prs.yml
+++ b/.github/workflows/lint-conventional-prs.yml
@@ -1,8 +1,10 @@
 name: Lint PR Title
 run-name: ${{github.event.pull_request.title}}
 
+permissions: { }
+
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -1,5 +1,7 @@
 name: Lint golangci
 
+permissions: { }
+
 on:
   pull_request:
     branches: ["main"]

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -1,6 +1,8 @@
 name: Lint Markdown Links
 run-name: ${{github.event.pull_request.title}}
 
+permissions: { }
+
 on:
   pull_request:
   schedule:

--- a/.github/workflows/report-sprint-commits.yml
+++ b/.github/workflows/report-sprint-commits.yml
@@ -1,6 +1,8 @@
 name: Report Sprint Test Suites
 run-name: A report for sprint commits
 
+permissions: { }
+
 # The report generation is performed ad hoc via manual invocation.
 on: workflow_dispatch
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removes the permissions from all GH workflows except for the ones explicitly requiring permissions, those limited to the minimum
  - `permissions: { }` disables all permissions for the workflow
- changes PR Title Lint from `pull_request_target` to `pull_request`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- closes https://github.com/kyma-project/lifecycle-manager/issues/2263
