### PR TITLE
chore: Bump go version and golangci-lint with action

### DIFF
--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -17,13 +17,13 @@ jobs:
           go-version-file: 'go.mod'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.0
         with:
-          version: v1.60.3
+          version: v1.64.7
           args: --verbose
       - name: golangci-lint for api module
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.0
         with:
-          version: v1.60.3
+          version: v1.64.7
           args: --verbose
           working-directory: ./api

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,6 +87,7 @@ issues:
         - wrapcheck # Errors do not need to be wrapped in unit and integration tests
         - err113 # Dynamic error creation in unit and integration tests is ok
         - gochecknoglobals # Does not apply to unit and integration tests
+        - fatcontext # Tests will use fatcontext for convenience
         - funlen # Table driven unit and integration tests exceed function length by design
         - maintidx # Table driven unit and integration tests exceed maintainability index by design
     - linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.6-alpine as builder
+FROM golang:1.24.1-alpine as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
-GOLANG_CI_LINT_VERSION ?= v1.60.3
+GOLANG_CI_LINT_VERSION ?= v1.64.7
 .PHONY: lint
 lint: ## Download & Build & Run golangci-lint against code.
 	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANG_CI_LINT_VERSION)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -50,7 +50,6 @@ var (
 )
 
 const (
-	testChartPath               = "./test/busybox"
 	rateLimiterBurstDefault     = 200
 	rateLimiterFrequencyDefault = 30
 	failureBaseDelayDefault     = 1 * time.Second

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/template-operator
 
-go 1.23.6
+go 1.24.1
 
 replace github.com/kyma-project/template-operator/api => ./api
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Bump go to 1.24.1
- Bump to latest golangci-lint action
- Use latest golangci-lint and fix issues

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
