### PR TITLE
chore: Fix permissions for release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,7 @@
 name: "Create release"
 
 permissions:
+  id-token: write
   contents: write
 
 on:


### PR DESCRIPTION
**Description**

The `Create Release` workflow [fails with](https://github.com/kyma-project/template-operator/actions/runs/15484285137):
```
The workflow is not valid. .github/workflows/create-release.yml (Line: 67, Col: 3): Error calling workflow 'kyma-project/template-operator/.github/workflows/build-image.yml@5ace91a0293824c8281be7d231c84c7456da90e0'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

Changes proposed in this pull request:

- Add "id-token: write" permission to the release workflow


**Related issue(s)**
