### PR TITLE
chore: Fix release workflow

### DIFF
--- a/.github/scripts/release/create_changelog.sh
+++ b/.github/scripts/release/create_changelog.sh
@@ -9,14 +9,13 @@ set -o pipefail
 RELEASE_VERSION=$1
 PREVIOUS_RELEASE=$2
 
-
 if [ "${PREVIOUS_RELEASE}"  == "" ]
 then
   PREVIOUS_RELEASE=$(git describe --tags --abbrev=0)
 fi
 
 GITHUB_URL=https://api.github.com/repos/${CODE_REPOSITORY}
-GITHUB_AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
+GITHUB_AUTH_HEADER="Authorization: Bearer ${GITHUB_TOKEN}"
 CHANGELOG_FILE="CHANGELOG.md"
 
 echo "## What has changed" >> ${CHANGELOG_FILE}
@@ -48,6 +47,6 @@ then
   done <${NEW_CONTRIB}
 fi
 
-echo -e "\n**Full changelog**: https://github.com/$REPOSITORY/compare/${PREVIOUS_RELEASE}...${RELEASE_VERSION}" >> ${CHANGELOG_FILE}
+echo -e "\n**Full changelog**: ${GITHUB_URL}/compare/${PREVIOUS_RELEASE}...${RELEASE_VERSION}" >> ${CHANGELOG_FILE}
 
 rm ${NEW_CONTRIB} || echo "cleaned up"


### PR DESCRIPTION
**Description**
There is an invalid variable reference error in the file: `github/scripts/release/create_changelog.sh.github/scripts/release/create_changelog.sh` 

Changes proposed in this pull request:

- Fix invalid variable reference

**Related issue(s)**