### PR TITLE
chore: Update image version in sec-scanners-config

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -6,7 +6,7 @@ checkmarx-one:
     - "**/test/**"
     - "**/*_test.go"
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/template-operator:1.0.1
+  - europe-docker.pkg.dev/kyma-project/prod/template-operator:1.0.2
   - europe-docker.pkg.dev/kyma-project/prod/template-operator:latest
 mend:
   language: golang-mod


### PR DESCRIPTION
**Description**

Bump image version in the `sec-scanners-config.yaml` file in order to resolve security vulnerabilities that are reported for external dependencies present in version `1.0.1`

Changes proposed in this pull request:

-  Update image version in sec-scanners-config to `1.0.2`

**Related issue(s)**