### PR TITLE
chore: Bump Go to 1.25.1; golangci-lint to 2.4.0

### DIFF
--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -18,7 +18,3 @@ runs:
         pwd
         cat versions.yaml
         echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
-    - name: Expose environment variables
-      shell: bash
-      run: |
-        echo "GOSUMDB=off" >> $GITHUB_ENV

--- a/.github/actions/configuration/action.yml
+++ b/.github/actions/configuration/action.yml
@@ -1,0 +1,24 @@
+name: configuration
+description: Defines configuration variables such as versions read from the versions.yaml file. Exposes globally needed environment variables.
+outputs:
+  golangci_lint_version:
+    description: The version of golangci-lint to use. For example, 1.60.3.
+    value: ${{ steps.define-variables.outputs.golangci_lint_version }}
+runs:
+  using: composite
+  steps:
+    - name: Install yq
+      uses: kyma-project/lifecycle-manager/.github/actions/install-yq@main
+      with:
+        yq_version: 4.45.1
+    - name: Define variables
+      id: define-variables
+      shell: bash
+      run: |
+        pwd
+        cat versions.yaml
+        echo "golangci_lint_version=$(yq e '.golangciLint' versions.yaml)" >> $GITHUB_OUTPUT
+    - name: Expose environment variables
+      shell: bash
+      run: |
+        echo "GOSUMDB=off" >> $GITHUB_ENV

--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -16,14 +16,17 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
+      - name: Get configuration
+        uses: ./.github/actions/configuration
+        id: configuration
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v${{ steps.configuration.outputs.golangci_lint_version }}
           args: --verbose
       - name: golangci-lint for api module
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v${{ steps.configuration.outputs.golangci_lint_version }}
           args: --verbose
           working-directory: ./api

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,8 @@ linters:
     - paralleltest
     - sqlclosecheck
     - wsl
+    - wsl_v5 # too strict
+    - noinlineerr # we want to keep inlining
   settings:
     cyclop:
       max-complexity: 20

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/template-operator/api
 
-go 1.24.4
+go 1.25.1
 
 require k8s.io/apimachinery v0.34.1
 

--- a/api/v1alpha1/managed_types.go
+++ b/api/v1alpha1/managed_types.go
@@ -33,5 +33,6 @@ type Managed struct {
 type ManagedList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Managed `json:"items"`
+
+	Items []Managed `json:"items"`
 }

--- a/api/v1alpha1/sample_types.go
+++ b/api/v1alpha1/sample_types.go
@@ -101,5 +101,6 @@ type Sample struct {
 type SampleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Sample `json:"items"`
+
+	Items []Sample `json:"items"`
 }

--- a/api/v1alpha1/thirdparty_types.go
+++ b/api/v1alpha1/thirdparty_types.go
@@ -33,5 +33,6 @@ type ThirdParty struct {
 type ThirdPartyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ThirdParty `json:"items"`
+
+	Items []ThirdParty `json:"items"`
 }

--- a/controllers/sample_controller_rendered_resources.go
+++ b/controllers/sample_controller_rendered_resources.go
@@ -44,10 +44,11 @@ import (
 // SampleReconciler reconciles a Sample object.
 type SampleReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 	*rest.Config
-	// EventRecorder for creating k8s events
 	record.EventRecorder
+
+	Scheme *runtime.Scheme
+	// EventRecorder for creating k8s events
 	FinalState         v1alpha1.State
 	FinalDeletionState v1alpha1.State
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/template-operator
 
-go 1.24.4
+go 1.25.1
 
 replace github.com/kyma-project/template-operator/api => ./api
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,0 +1,5 @@
+golangciLint: "2.4.0"
+envtest: "0.21"
+envtest_k8s: "1.32.0"
+kustomize: "5.4.3"
+controllerTools: "0.19.0"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

-  bumps Go to 1.25.1
-  bumps golangci-lint to 2.4.0
-  installs golangci-lint from binary
- introduces `versions.yaml`
  - Makefile reads versions from yaml
- introduces GH action to get configuration from versions yaml
  - configures linting action to use this version


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
