### PR TITLE
docs: Add Claude Code baseline: CLAUDE.md

### DIFF
--- a/.claude/agents/principal-engineer.md
+++ b/.claude/agents/principal-engineer.md
@@ -1,0 +1,70 @@
+---
+name: principal-engineer
+description: Senior engineering design review. Use when you want judgment on whether an approach is architecturally sound — new abstractions, controller changes, SSA pattern deviations, significant refactors. This is the reference implementation for Kyma modules; design decisions here become the pattern every module team copies. Invoke with: "Use the principal-engineer agent to review this design."
+tools: Read, Grep, Glob
+model: claude-opus-4-7
+color: purple
+maxTurns: 25
+---
+
+You are a principal software engineer reviewing changes to template-operator — the **canonical reference implementation for Kyma module operators**. Every pattern here will be copied by module teams building production operators. Design decisions carry outsized weight: a bad pattern here becomes a bad pattern in dozens of downstream repos.
+
+You have read-only access to the codebase. Browse as much context as you need before forming an opinion.
+
+## What you evaluate
+
+### 1. Is this the right pattern for module operators to copy?
+- Would a developer new to Kyma modules understand why this pattern exists?
+- Is the pattern general enough to apply across different module operators, or is it specific to template-operator's toy use case?
+- If a module team copies this verbatim, will they end up with maintainable production code?
+
+### 2. SSA correctness
+- All resource creation and update must use Server-Side Apply (`r.Client.Patch` with `client.Apply` and a field owner). Never `Create`, `Update`, or `Patch` with MergePatch for managed resources.
+- Status updates must use SSA via `ssaStatus`, not `r.Status().Update()`.
+- Is the field owner string consistent and meaningful?
+
+### 3. State machine integrity
+- The state machine is: `(new) → Processing → Ready`, with `Error` and `Deleting` as branches.
+- Are new states or transitions necessary, or can the existing states express the new behaviour?
+- Is the transition logic deterministic — can you trace exactly which condition leads to which state?
+
+### 4. Simplicity (reference code must be readable)
+- This is tutorial code as much as production code. Is it as simple as it can be while still demonstrating the real patterns?
+- Would adding a feature obscure the core reconcile loop for a developer trying to learn from it?
+
+### 5. Abstraction fitness
+- Are types and interfaces at the domain level (Sample CR, reconciliation state) rather than the implementation level?
+- Is naming self-documenting without comments?
+
+### 6. Error philosophy
+- Errors wrapped with `fmt.Errorf("context: %w", err)`?
+- Transient vs. permanent failure distinguished by return value (`ctrl.Result` vs. `error`)?
+- `Installation` condition updated to reflect the failure mode?
+
+### 7. Testability
+- New behaviour testable with `envtest` + Ginkgo in `controllers/`?
+- Does the test use the same `SampleReconciler` wired against the real envtest environment (not mocks)?
+
+## Output format
+
+```
+## Principal Engineer Review
+
+### Design assessment
+[2-4 sentences — is the pattern right for a reference implementation?]
+
+### Concerns
+- [HIGH] <file>:<line> — <issue and why it matters for downstream module teams>
+- [MEDIUM] <file>:<line> — <concern>
+- [LOW] <file>:<line> — <minor observation>
+
+### What works well
+- <concrete, specific>
+
+### Verdict
+APPROVE / REQUEST CHANGES / REJECT
+
+[Decisive factor — especially: should downstream module teams copy this?]
+```
+
+REJECT means the fundamental approach sets a bad precedent — explain what pattern should be established instead. REQUEST CHANGES means the approach is right but specific decisions need correcting before this becomes the canonical example. APPROVE means you would merge this and recommend it as a reference pattern.

--- a/.claude/cve-triage/context.md
+++ b/.claude/cve-triage/context.md
@@ -1,0 +1,109 @@
+# CVE Triage Context — template-operator
+
+Two distinct CVE surfaces: container/OS level (BDBA) and Go code level (Mend + Checkmarx).
+
+template-operator is the **reference implementation for Kyma module operators** (`kind: kyma`). It deploys on SKR clusters, not KCP. No FIPS requirement.
+
+---
+
+## Surface 1: Container image (BDBA findings)
+
+### Image tracked
+
+#### template-operator
+- **Registry**: `europe-docker.pkg.dev/kyma-project/prod/template-operator`
+- **Scanned tags**: `latest` and the two most recent release tags (see `sec-scanners-config.yaml`)
+- **Base image**: `gcr.io/distroless/static:nonroot` — **floating tag, not digest-pinned**
+  - Base image updates happen automatically on rebuild — BDBA is the primary signal for new OS-level CVEs
+- **Builder**: Go static binary (`CGO_ENABLED=0`, no FIPS requirement)
+- **Runtime user**: nonroot
+
+### Image CVE triage logic
+
+1. **Is the vulnerable package present?**
+   - `gcr.io/distroless/static` contains: `ca-certificates`, `tzdata`, glibc stubs only
+   - CVEs in bash, curl, openssl, apt, python, libc → **not applicable** (not in the image)
+   - `CGO_ENABLED=0` means no glibc linkage — glibc CVEs → **not applicable**
+
+2. **Base image is floating — regression check:**
+   - If a new CVE appears after a release, check whether the distroless tag was updated between builds
+   - Fix: pin to sha256 digest in `Dockerfile`, or open a tracking issue
+
+---
+
+## Surface 2: Go module dependencies (Mend SCA findings)
+
+### Go module structure — two modules
+
+| Directory | Module path | Notes |
+|---|---|---|
+| root | `github.com/kyma-project/template-operator` | Main controller |
+| `api/` | `github.com/kyma-project/template-operator/api` | Separate module — has its own `go.mod` |
+
+Mend scans both modules. Run `go` commands from the appropriate directory.
+
+### Go module CVE triage logic
+
+1. **Which module is affected?**
+   ```sh
+   # Root module
+   go list -m -json all | jq 'select(.Path == "<module>")'
+   # API sub-module
+   cd api && go list -m -json all | jq 'select(.Path == "<module>")'
+   ```
+
+2. **Is the module reachable from production code?**
+   ```sh
+   go mod why <module>
+   ```
+   If the chain only passes through `test/` or `_test.go` files → **not applicable in production**.
+
+3. **Is there a fixed version?**
+   ```sh
+   go get <module>@<fixed-version>
+   go mod tidy
+   make test
+   ```
+   Open a `deps` PR per affected module. Title: `deps: bump <module> to <version> (CVE-XXXX-XXXXX)`
+   After any type change in `api/`: run both `make generate` and `make manifests` before the PR.
+
+4. **No FIPS constraint** — template-operator does not use `GOFIPS140`. Crypto library substitutions do not need FIPS validation. However, do not use `InsecureSkipVerify` or weak cipher suites.
+
+5. **No fix available?**
+   - template-operator processes only resources from the cluster it's installed on — not exposed to untrusted internet traffic directly
+   - Document assessment in CVE tracking issue; suppression requires security team approval
+
+---
+
+## Surface 3: Go source code (Checkmarx One SAST findings)
+
+### Checkmarx scope
+
+- Preset: `go-default`
+- Excludes: `**/test/**`, `**/*_test.go`
+- Scans: all production Go source
+
+### SAST triage logic
+
+1. **Is the finding a true positive?**
+   - template-operator reads YAML manifests from `Sample.spec.resourceFilePath` (a local directory path set in the CR) and applies them via Server-Side Apply — the operator is not a web service
+   - Checkmarx commonly false-positives on: `os.ReadFile` with CR-specified paths (operator-controlled, not user-supplied), YAML marshalling, log statements
+
+2. **True positives to take seriously:**
+   - `os.ReadFile` / `filepath.Join` where the path is constructed from user-supplied CR fields without sanitization — could be path traversal in a multi-tenant context
+   - Hardcoded credentials in source (not test fixtures)
+   - Any `exec.Command` with dynamic arguments
+
+3. **SSA pattern:** template-operator uses Server-Side Apply exclusively (`r.Client.Patch` with `client.Apply`). Never replace SSA with `Create`/`Update` — this breaks ownership semantics and can cause reconciliation conflicts.
+
+---
+
+## Scanner configuration reference
+
+Defined in `sec-scanners-config.yaml` (`kind: kyma`):
+
+| Scanner | Type | Scope | Excludes |
+|---|---|---|---|
+| **BDBA** | Container binary scan | Production image | — |
+| **Mend** | Go module SCA | Root + `api/` `go.mod` | `test/`, `*_test.go` |
+| **Checkmarx One** | Go SAST | All Go source (`go-default`) | `test/`, `*_test.go` |

--- a/.claude/rules/go-conventions.md
+++ b/.claude/rules/go-conventions.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go code conventions — template-operator
+
+`make lint` is the authoritative check. The full linter config is in `.golangci.yaml`.
+
+## nolint policy
+
+Every `//nolint` directive **must** include an explanation:
+```go
+//nolint:funlen // reconcile loop — acceptable exception
+```
+Bare `//nolint:funlen` fails CI (`nolintlint` is enabled). Check `.golangci.yaml` before adding any suppression.
+
+## SSA — never use Create/Update for managed resources
+
+All resource creation and updates must go through Server-Side Apply:
+```go
+// correct
+r.Client.Patch(ctx, obj, client.Apply, client.ForceOwnership, client.FieldOwner("sample.kyma-project.io/owner"))
+
+// wrong — breaks ownership semantics
+r.Client.Create(ctx, obj)
+r.Client.Update(ctx, obj)
+```
+Status updates use `ssaStatus`, not `r.Status().Update()`. This is the pattern module teams copy — keep it correct.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+template-operator is the **reference implementation for Kyma module operators**. It is not a production component — it is the canonical starting point developers copy when building a new Kyma module. Any pattern here is intentional and should be treated as the recommended way to implement a Kyma module operator.
+
+## Module & language
+
+- Module: `github.com/kyma-project/template-operator` (Go 1.26.1)
+- API is a **separate Go module**: `github.com/kyma-project/template-operator/api`
+- Key dependencies: `controller-runtime v0.24.0`, `k8s.io/* v0.36.0`
+- Tool versions pinned in `versions.yaml`
+
+## Make targets
+
+Run from the repo root:
+
+| Target | What it does |
+|---|---|
+| `make generate` | Regenerate `zz_generated.deepcopy.go` via controller-gen |
+| `make manifests` | Regenerate CRD YAML (`config/crd/bases/`) and RBAC via controller-gen |
+| `make test` | Run all tests with envtest (also runs generate/manifests/fmt/vet) |
+| `make build` | Run generate, fmt, vet, lint, then compile `bin/manager` |
+| `make lint` | golangci-lint on root and `api/` |
+| `make fmt` / `make vet` | `go fmt` / `go vet` |
+| `make build-manifests` | Build static `template-operator.yaml` (Deployment) for release |
+| `make build-module` | Build Kyma module artifact via `kyma alpha create module` |
+
+**After any type change in `api/`**: run both `make generate` and `make manifests`.
+
+### Running a single test
+
+```sh
+KUBEBUILDER_ASSETS=$(./bin/setup-envtest use 1.32.0 -p path) \
+  go test ./controllers/... -v -ginkgo.focus "some spec description"
+```
+
+Run `make envtest` once after checkout to populate `bin/setup-envtest`.
+
+## Architecture
+
+### Single controller
+
+`controllers/sample_controller_rendered_resources.go` — `SampleReconciler` is the only controller. It:
+1. Reads YAML manifests from the path specified in `Sample.spec.resourceFilePath`
+2. Parses them into unstructured objects
+3. Applies them to the cluster using **Server-Side Apply (SSA)** — never `Create`/`Update` directly
+4. Transitions the `Sample` CR through the state machine
+
+### State machine
+
+```
+(new) ──► Processing ──► Ready
+                    └──► Error ──► (retry → Ready)
+                    └──► Deleting ──► (finalizer removed)
+```
+
+Final states are configurable via flags: `--final-state` (default `Ready`) and `--final-deletion-state` (default `Deleting`). Tests set `FinalDeletionState=Warning` to verify warning path.
+
+### CRD — `Sample` (`api/v1alpha1`)
+
+```
+operator.kyma-project.io/v1alpha1/Sample
+```
+
+- `spec.resourceFilePath` — local directory containing exactly one `.yaml`/`.yml` file to apply
+- `status.state` — enum: `Ready | Processing | Error | Deleting | Warning`
+- `status.conditions` — standard `[]metav1.Condition`; single condition: `Installation`
+
+Finalizer: `sample.kyma-project.io/finalizer`
+SSA field owner: `sample.kyma-project.io/owner`
+
+### Deployment modes
+
+Two kustomize overlays — `config/overlays/deployment/` and `config/overlays/statefulset/`. Use `make deploy` or `make deploy-statefulset`. Both inject `--final-state` and `--final-deletion-state` args.
+
+## Code conventions
+
+- **Status updates use SSA** (`ssaStatus`) — never `r.Status().Update()` directly
+- **Resource application uses SSA** (`ssa`) — never `r.Create()` / `r.Update()` for managed resources
+- **Conditions** set via `status.WithInstallConditionStatus(metav1.ConditionTrue/False, generation)`
+- **RBAC markers** live in the controller file, not in `api/`
+
+## Testing
+
+Tests live in `controllers/` alongside the controller (not in a separate `tests/` directory). The suite bootstrap in `suite_test.go` wires the full `SampleReconciler` against an envtest environment. Test fixtures (busybox manifests) are in `controllers/test/busybox/manifest/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,10 @@ Two kustomize overlays — `config/overlays/deployment/` and `config/overlays/st
 
 Tests live in `controllers/` alongside the controller (not in a separate `tests/` directory). The suite bootstrap in `suite_test.go` wires the full `SampleReconciler` against an envtest environment. Test fixtures (busybox manifests) are in `controllers/test/busybox/manifest/`.
 
+## Code conventions
+
+Go nolint policy and SSA pattern rules load automatically when editing `.go` files — see [`.claude/rules/go-conventions.md`](.claude/rules/go-conventions.md).
+
 ## CVE triage
 
 Three scanners run against this repo (`sec-scanners-config.yaml`): **Checkmarx One** (SAST), **BDBA** (container CVE scan), **Mend** (Go module SCA for root and `api/` modules). When triaging a CVE finding, see [`.claude/cve-triage/context.md`](.claude/cve-triage/context.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,10 @@ Two kustomize overlays — `config/overlays/deployment/` and `config/overlays/st
 
 Tests live in `controllers/` alongside the controller (not in a separate `tests/` directory). The suite bootstrap in `suite_test.go` wires the full `SampleReconciler` against an envtest environment. Test fixtures (busybox manifests) are in `controllers/test/busybox/manifest/`.
 
+## CVE triage
+
+Three scanners run against this repo (`sec-scanners-config.yaml`): **Checkmarx One** (SAST), **BDBA** (container CVE scan), **Mend** (Go module SCA for root and `api/` modules). When triaging a CVE finding, see [`.claude/cve-triage/context.md`](.claude/cve-triage/context.md).
+
 ## Model usage
 
 Follow the Kyma team's Claude Code workflow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,12 @@ Two kustomize overlays — `config/overlays/deployment/` and `config/overlays/st
 ## Testing
 
 Tests live in `controllers/` alongside the controller (not in a separate `tests/` directory). The suite bootstrap in `suite_test.go` wires the full `SampleReconciler` against an envtest environment. Test fixtures (busybox manifests) are in `controllers/test/busybox/manifest/`.
+
+## Model usage
+
+Follow the Kyma team's Claude Code workflow:
+
+- **Planning complex tasks** — switch to Opus: `/model claude-opus-4-7`
+- **Implementation** — use the default Sonnet: `/model claude-sonnet-4-6`
+
+Use Opus when you need to understand an unfamiliar subsystem, design a non-trivial change, or reason about cross-cutting impacts. Switch back to Sonnet once the approach is clear and you are writing code.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at repo root so every Claude Code session starts with accurate context about this repo
- Covers: what this repo is (reference implementation for Kyma module operators), make targets, single-test commands, the `Sample` state machine, SSA-based resource application, CRD conventions, deployment modes (Deployment vs StatefulSet overlay), and test setup

## Motivation

Part of the Jellyfish team initiative to add Claude Code baseline context to all team repos (see kyma-project/lifecycle-manager#3241). This is the template-operator complement to lifecycle-manager#3248.

## Test plan

- [ ] Open a Claude Code session in this repo and confirm `CLAUDE.md` loads at session start with correct make targets and architecture context