### PR TITLE
fix: Prevent code injection in publish-image-local workflow

### DIFF
--- a/.github/workflows/publish-image-local.yml
+++ b/.github/workflows/publish-image-local.yml
@@ -34,11 +34,15 @@ jobs:
 
       - name: Compute image tags
         id: tags
+        env:
+          WR_EVENT: ${{ github.event.workflow_run.event }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          event="${{ github.event.workflow_run.event }}"
-          sha="${{ github.event.workflow_run.head_sha }}"
+          event="$WR_EVENT"
+          sha="$WR_HEAD_SHA"
           short_sha="${sha:0:7}"
-          head_branch="${{ github.event.workflow_run.head_branch }}"
+          head_branch="$WR_HEAD_BRANCH"
           # pull_requests is only populated for same-repo PRs, empty for forks.
           pr_number=$(jq -r '.workflow_run.pull_requests[0].number // ""' "$GITHUB_EVENT_PATH")
 


### PR DESCRIPTION
## Summary
- Fixes code scanning alert #3 (critical): potential code injection via `${{ github.event.workflow_run.head_branch }}` in a `run:` block
- Moves `workflow_run` context values (`head_branch`, `head_sha`, `event`) into `env:` variables and references them with shell syntax, preventing shell injection via maliciously-named branches

## Test plan
- [ ] Verify the workflow still triggers correctly on a successful `workflow_run` event
- [ ] Confirm code scanning alert #3 is resolved after merge