### PR TITLE
chore: Fix workflow permissions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -60,6 +60,7 @@ jobs:
     needs: [get-custom-tags, who-am-i]
     permissions:
       id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: template-operator


### PR DESCRIPTION
**Description**

Add `contents: read` to the `build-image` job's permissions block

Changes proposed in this pull request:

- Add `contents: read` to the `build-image` job's permissions block
