### PR TITLE
chore: Add `trusted-authors.yaml`

### DIFF
--- a/.github/trusted-authors.yaml
+++ b/.github/trusted-authors.yaml
@@ -1,0 +1,3 @@
+authors:
+  - Tomasz-Smelcerz-SAP
+  - c-pius

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -63,17 +63,30 @@ jobs:
             echo "environment=restricted" >> $GITHUB_OUTPUT
           fi
 
-  build-image:
+  build-image-trusted:
     needs: [get-custom-tags, check-author]
+    if: needs.check-author.outputs.environment == 'trusted'
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
-    environment: ${{ needs.check-author.outputs.environment }}
+    environment: trusted
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: template-operator
       dockerfile: Dockerfile
       context: .
-      # tags are additional tags that will be added to the image on top of the default ones
-      # default tags are documented here: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#default-tags
+      tags: ${{ needs.get-custom-tags.outputs.tags }}
+
+  build-image-restricted:
+    needs: [get-custom-tags, check-author]
+    if: needs.check-author.outputs.environment == 'restricted'
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
+    environment: restricted
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: template-operator
+      dockerfile: Dockerfile
+      context: .
       tags: ${{ needs.get-custom-tags.outputs.tags }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -39,28 +39,36 @@ jobs:
           echo "Using custom tags: '$tags'"
           echo "tags=$tags" >> $GITHUB_OUTPUT
 
-  who-am-i:
+  check-author:
     runs-on: ubuntu-latest
-    environment: image-build
+    outputs:
+      environment: ${{ steps.check.outputs.environment }}
     steps:
-      - name: Show my association
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Check if author is trusted
+        id: check
         run: |
-          echo "Author association: ${{ github.event.pull_request.author_association }}"
-      - name: Check if OWNER
-        if: ${{ github.event.pull_request.author_association == 'OWNER' }}
-        run: echo "You are an OWNER"
-      - name: Check if COLLABORATOR
-        if: ${{ github.event.pull_request.author_association == 'COLLABORATOR' }}
-        run: echo "You are a COLLABORATOR"
-      - name: Otherwise
-        if: ${{ github.event.pull_request.author_association != 'OWNER' && github.event.pull_request.author_association != 'COLLABORATOR' }}
-        run: echo "You are neither OWNER nor COLLABORATOR"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          if [[ -z "$AUTHOR" ]]; then
+            # Non-PR events (push, workflow_call) are always trusted
+            echo "environment=trusted" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if grep -qx "  - $AUTHOR" .github/trusted-authors.yaml; then
+            echo "Author '$AUTHOR' is trusted"
+            echo "environment=trusted" >> $GITHUB_OUTPUT
+          else
+            echo "Author '$AUTHOR' is not trusted"
+            echo "environment=restricted" >> $GITHUB_OUTPUT
+          fi
 
   build-image:
-    needs: [get-custom-tags, who-am-i]
+    needs: [get-custom-tags, check-author]
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
+    environment: ${{ needs.check-author.outputs.environment }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: template-operator


### PR DESCRIPTION
**Description**

Add `trusted-authors.yaml` that explicitly lists users that can open "trusted" PRs.
A "trusted PR" doesn't require explicit approval for running "build-image" job, which runs as `pull_request_target` and so is potentially dangerous.

If the PR is not trusted, a preliminary review is required to ensure that the PR:
- does not inject malicious code/behavior to any script or configuration used by the pipelines used in the project.
- does not inject malicious code into Dockerfile
- does not inject malicious code into GitHub logic (actions/workflows)

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
