### PR TITLE
chore: Add `build-image-success` job

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -105,3 +105,18 @@ jobs:
       dockerfile: Dockerfile
       context: .
       tags: ${{ needs.get-custom-tags.outputs.tags }}
+
+  build-image-success:
+    needs: [build-image-trusted, build-image-restricted]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check build result
+        run: |
+          if [[ "${{ needs.build-image-trusted.result }}" == "success" || \
+                "${{ needs.build-image-restricted.result }}" == "success" ]]; then
+            echo "Image build succeeded."
+          else
+            echo "Image build failed or was skipped for both paths."
+            exit 1
+          fi


### PR DESCRIPTION
**Description**

Add single `build-image-success` job that can be used as a "required" one.
The `build-image-success` runs after either `build-image-trusted` or `build-image-restricted`

Changes proposed in this pull request:

- Add `build-image-success` job