### PR TITLE
chore: Fix workflow definition

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -39,12 +39,17 @@ jobs:
           echo "Using custom tags: '$tags'"
           echo "tags=$tags" >> $GITHUB_OUTPUT
 
-  build-image:
+  restricted-gate:
     needs: get-custom-tags
     runs-on: ubuntu-latest
     environment:
       name: restricted
       deployment: false
+    steps:
+      - run: echo "'build-image' job approval granted"
+
+  build-image:
+    needs: [get-custom-tags, restricted-gate]
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout


### PR DESCRIPTION
**Description**

Fixes a problem introduced in #508 

Claude analysis for future reference:
```
The problem is on lines 51-52: a job can't mix **uses** (for calling a reusable workflow) with **environment** (lines 45-47).
In GitHub Actions, a job using **uses** to call a reusable workflow cannot have **environment** set — it's not a valid combination.
```

Additional docs providing which properties are allowed in a jub using another workflow (`environment` is not on this list):
https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#supported-keywords-for-jobs-that-call-a-reusable-workflow

Changes proposed in this pull request:

- Fix workflow definition