### PR TITLE
chore: Split build-image workflow

### DIFF
--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -1,19 +1,11 @@
-name: Build Image
+name: Build PR Image
 
 permissions:
   contents: read # This is required for actions/checkout
 
 on:
-  push:
-    branches:
-      - main
-  workflow_call:
-    inputs:
-      tag:
-        description: 'Additional tag for built image'
-        required: false
-        type: string
-        default: ""
+  pull_request_target:
+    types: [ opened, edited, synchronize, reopened, ready_for_review ]
 
 jobs:
   get-custom-tags:
@@ -27,16 +19,22 @@ jobs:
         id: get_custom_tags
         run: |
           tags=""
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            tags="latest"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            tags="${{ inputs.tag }}"
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            tags="${{ github.event.pull_request.head.sha }}"
           fi
           echo "Using custom tags: '$tags'"
           echo "tags=$tags" >> $GITHUB_OUTPUT
 
-  build-image:
-    needs: [get-custom-tags]
+  restricted-gate:
+    needs: get-custom-tags
+    runs-on: ubuntu-latest
+    environment:
+      name: restricted
+    steps:
+      - run: echo "'build-image' job approval granted"
+
+  build-pr-image:
+    needs: [get-custom-tags, restricted-gate]
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -8,25 +8,7 @@ on:
     types: [ opened, edited, synchronize, reopened, ready_for_review ]
 
 jobs:
-  get-custom-tags:
-    runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.get_custom_tags.outputs.tags }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-      - name: Get tags
-        id: get_custom_tags
-        run: |
-          tags=""
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            tags="${{ github.event.pull_request.head.sha }}"
-          fi
-          echo "Using custom tags: '$tags'"
-          echo "tags=$tags" >> $GITHUB_OUTPUT
-
   restricted-gate:
-    needs: get-custom-tags
     runs-on: ubuntu-latest
     environment:
       name: restricted
@@ -34,7 +16,7 @@ jobs:
       - run: echo "'build-image' job approval granted"
 
   build-pr-image:
-    needs: [get-custom-tags, restricted-gate]
+    needs: restricted-gate
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
@@ -45,4 +27,4 @@ jobs:
       context: .
       # tags are additional tags that will be added to the image on top of the default ones
       # default tags are documented here: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#default-tags
-      tags: ${{ needs.get-custom-tags.outputs.tags }}
+      tags: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request_target:
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 jobs:
   restricted-gate:


### PR DESCRIPTION
**Description**

Split the `build-image.yml` workflow into two separate workflows:
- "Build Image" that runs on `push-to-main` and during release builds. This one doesn't need `restricted-gate` protection because an attacker can't inject malicious code (there is no external, untrusted PR involved)
- "Build PR Image" that is triggered on `pull-request-target`. This one needs the `restricted-gate` protection to prevent PR-based workflow poisoning attacks.

This split was necessary because otherwise `push-to-main` runs were also blocked by `restricted-gate`, which is not correct behavior. We could handle it via some conditional logic, but we decided not to: This increases complexity, makes it harder to verify if the solution is secure, adds a chance for an attack based on exploiting potential flaws in the conditional logic.

See also: #508 

Changes proposed in this pull request:

- Split the `build-image.yml` workflow into two separate ones.
- Simplify the `build-pr-image` workflow to be minimal