### PR TITLE
chore: Add `template-operator` tailored `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,14 +8,9 @@
     ":semanticCommitScopeDisabled",
     "helpers:pinGitHubActionDigests"
   ],
-  "labels": [
-    "area/dependency",
-    "kind/chore"
-  ],
+  "labels": ["area/dependency", "kind/chore"],
   "gomod": {
-    "postUpdateOptions": [
-      "gomodTidy"
-    ],
+    "postUpdateOptions": ["gomodTidy"],
     "enabled": true
   },
   "kustomize": {
@@ -30,68 +25,48 @@
   "github-actions": {
     "enabled": true
   },
-  "ignoreDeps": [
-    "github.com/kyma-project/template-operator/api",
-    "kyma-project/lifecycle-manager",
-    "kyma-project/test-infra"
-  ],
+  "ignoreDeps": ["github.com/kyma-project/template-operator/api"],
   "packageRules": [
     {
-      "matchCategories": [
-        "golang"
-      ],
-      "postUpdateOptions": [
-        "gomodTidy"
-      ],
-      "enabled": true
-    },
-    {
-      "matchDatasources": [
-        "golang-version"
-      ],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepTypes": [
-        "indirect"
+      "matchManagers": ["github-actions"],
+      "matchDepNames": [
+        "kyma-project/lifecycle-manager",
+        "kyma-project/test-infra"
       ],
       "enabled": false
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
+      "matchCategories": ["golang"],
+      "postUpdateOptions": ["gomodTidy"],
+      "enabled": true
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
       "schedule": "every month",
       "enabled": false
     },
     {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "groupName": "All Kubernetes packages",
-      "matchPackagePrefixes": [
-        "k8s.io/",
-        "sigs.k8s.io/"
-      ]
+      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "groupName": "ginkgo-gomega",
       "matchPackageNames": [
         "github.com/onsi/ginkgo/v2",
@@ -99,8 +74,5 @@
       ]
     }
   ],
-  "ignorePaths": [
-    "docs/**",
-    "controllers/test/busybox/**"
-  ]
+  "ignorePaths": ["docs/**", "controllers/test/busybox/**"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,106 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "osvVulnerabilityAlerts": true,
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScopeDisabled",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "labels": [
+    "area/dependency",
+    "kind/chore"
+  ],
+  "gomod": {
+    "postUpdateOptions": [
+      "gomodTidy"
+    ],
+    "enabled": true
+  },
+  "kustomize": {
+    "enabled": false
+  },
+  "dockerfile": {
+    "enabled": true
+  },
+  "helm-values": {
+    "enabled": false
+  },
+  "github-actions": {
+    "enabled": true
+  },
+  "ignoreDeps": [
+    "github.com/kyma-project/template-operator/api",
+    "kyma-project/lifecycle-manager",
+    "kyma-project/test-infra"
+  ],
+  "packageRules": [
+    {
+      "matchCategories": [
+        "golang"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ],
+      "enabled": true
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "schedule": "every month",
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "All Kubernetes packages",
+      "matchPackagePrefixes": [
+        "k8s.io/",
+        "sigs.k8s.io/"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "ginkgo-gomega",
+      "matchPackageNames": [
+        "github.com/onsi/ginkgo/v2",
+        "github.com/onsi/gomega"
+      ]
+    }
+  ],
+  "ignorePaths": [
+    "docs/**",
+    "controllers/test/busybox/**"
   ]
 }


### PR DESCRIPTION
**Description**

Here I introduce `renovate.json` tailored for `template-operator`.

**Related issue(s)**
[Lifecycle Manager Issue 2995](https://github.com/kyma-project/lifecycle-manager/issues/2995)