### PR TITLE
chore: Replace deprecated controller-runtime scheme.Builder with apimachinery runtime.SchemeBuilder

### DIFF
--- a/controllers/sample_controller_rendered_resources.go
+++ b/controllers/sample_controller_rendered_resources.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
 	"github.com/kyma-project/template-operator/api/v1alpha1"
 )
@@ -61,15 +60,16 @@ type ManifestResources struct {
 var (
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	//nolint:gochecknoglobals // used to register Sample CRD on startup
-	SchemeBuilder = &scheme.Builder{GroupVersion: v1alpha1.GroupVersion} //nolint:staticcheck // See #480
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	//nolint:gochecknoglobals // used to register Sample CRD on startup
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
-func init() { //nolint:gochecknoinits // used to register Sample CRD on startup
-	SchemeBuilder.Register(&v1alpha1.Sample{}, &v1alpha1.SampleList{})
+func addKnownTypes(s *runtime.Scheme) error {
+	s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.Sample{}, &v1alpha1.SampleList{})
+	return nil
 }
 
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=samples,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/sample_controller_rendered_resources.go
+++ b/controllers/sample_controller_rendered_resources.go
@@ -68,8 +68,15 @@ var (
 )
 
 func addKnownTypes(s *runtime.Scheme) error {
-	s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.Sample{}, &v1alpha1.SampleList{})
+	metav1.AddToGroupVersion(s, v1alpha1.GroupVersion)
 	return nil
+}
+
+func init() { //nolint:gochecknoinits // used to register Sample CRD on startup
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.Sample{}, &v1alpha1.SampleList{})
+		return nil
+	})
 }
 
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=samples,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Summary

- Replaces the deprecated `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` with `k8s.io/apimachinery/pkg/runtime.NewSchemeBuilder` in `controllers/sample_controller_rendered_resources.go`
- Removes the `//nolint:staticcheck // See #480` suppression and the `//nolint:gochecknoinits` suppression along with the `init()` function
- Registers types via a plain `addKnownTypes` function instead, following the pattern from kyma-project/lifecycle-manager#3290

Closes kyma-project/lifecycle-manager#3239