### PR TITLE
chore: Pin setup-go action version to `v6.4.0`

### DIFF
--- a/.github/workflows/create-release-api.yml
+++ b/.github/workflows/create-release-api.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "api/go.mod"
           cache-dependency-path: "api/go.sum"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Template Operator
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Run integration tests

--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: false


### PR DESCRIPTION
**Description**

This PR re-creates changes from #517 , because of some problems with `renovate` configuration that prevents it from being merged.

The renovate configuration problems are related to detecting timestamps on GitHub actions releases. Because of that the `renovate/stability-days` check blocks the PRs opened by `renovate`.

Changes proposed in this pull request:

- Pin `setup-go` action version to `v6.4.0`
